### PR TITLE
Initial stab at supporting systems that do not use 'python' as the Python 3 command

### DIFF
--- a/i3_lemonbar.py
+++ b/i3_lemonbar.py
@@ -1,20 +1,11 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 from i3_lemonbar_conf import *
 
-python3_command_map = {'ubuntu': 'python3',
-                       'arch': 'python',
-                       'default': 'python3'}
-try:
-    distribution = platform.linux_distribution()[0].lower()
-    python_command = python3_command_map[distribution]
-except (KeyError, IndexError, TypeError):
-    python_command = python3_command_map['default']
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 lemon = "lemonbar -p -f '%s' -f '%s' -g '%s' -B '%s' -F '%s'" % (font, iconfont, geometry, color_back, color_fore)
-feed = "{python_cmd} -c 'import i3_lemonbar_feeder; i3_lemonbar_feeder.run()'".format(python_cmd=python_command)
+feed = "python3 -c 'import i3_lemonbar_feeder; i3_lemonbar_feeder.run()'"
 
 check_output('cd %s; %s | %s' % (cwd, feed, lemon), shell=True)

--- a/i3_lemonbar.py
+++ b/i3_lemonbar.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
 
 import os
+import platform
 from i3_lemonbar_conf import *
+
+python3_command_map = {'ubuntu': 'python3',
+                       'arch': 'python',
+                       'default': 'python3'}
+try:
+    distribution = platform.linux_distribution()[0].lower()
+    python_command = python3_command_map[distribution]
+except (KeyError, IndexError, TypeError):
+    python_command = python3_command_map['default']
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 lemon = "lemonbar -p -f '%s' -f '%s' -g '%s' -B '%s' -F '%s'" % (font, iconfont, geometry, color_back, color_fore)
-feed = "python -c 'import i3_lemonbar_feeder; i3_lemonbar_feeder.run()'"
+feed = "{python_cmd} -c 'import i3_lemonbar_feeder; i3_lemonbar_feeder.run()'".format(python_cmd=python_command)
 
 check_output('cd %s; %s | %s' % (cwd, feed, lemon), shell=True)


### PR DESCRIPTION
yes we are backwards :(

Ubuntu currently still uses `python` for Python 2, while other distributions (e.g., Arch) use `python` for Python 3 and `python2` for Python 2.

This is a quick fix that uses the platform module to derive information about the system, specifically if it's an Ubuntu system in which case we know how to handle specifying version.